### PR TITLE
Enforce min version of w3c-keyname to be 1.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/prosemirror/prosemirror-keymap.git"
   },
   "dependencies": {
-    "w3c-keyname": "^1.1.0",
+    "w3c-keyname": "^1.1.8",
     "prosemirror-state": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Version below 1.1.8 has an issue when shortcuts with the Shift key (e.g. CMD+Shift+Z) is not working properly in Chrome (maybe other browsers too). 

It's happening because w3c-keyname returns z (as a lowercase z) instead of Z (uppercase Z) which is breaking those shortcuts. 

Even though version 1.1.8 satisfies specified semver range of '^1.1.0' tooling like yarn is not updating existing yarn locks... Solution could be to manually amend yarn.lock/package-lock.json, but I think it makes total sense to just force it in a package...