### PR TITLE
added: preventDefault to allow overriding browser key bindings

### DIFF
--- a/src/keymap.js
+++ b/src/keymap.js
@@ -80,6 +80,7 @@ export function keymap(bindings) {
 export function keydownHandler(bindings) {
   let map = normalize(bindings)
   return function(view, event) {
+    event.preventDefault();
     let name = keyName(event), isChar = name.length == 1 && name != " ", baseName
     let direct = map[modifiers(name, event, !isChar)]
     if (direct && direct(view.state, view.dispatch, view)) return true

--- a/test/test-keymap.js
+++ b/test/test-keymap.js
@@ -7,6 +7,9 @@ function dispatch(map, key, mods) {
   let event = {}
   if (mods) for (let prop in mods) event[prop] = mods[prop]
   event.key = key
+  event.preventDefault = () => {
+    // noop: include for ensuring tests run
+  }
   map.props.handleKeyDown(fakeView, event)
 }
 


### PR DESCRIPTION
We are building a link creation/editing experience. Most editing experiences use the command `Mod-k` to create/edit links. e.g. Gmail, Gdocs, Medium, etc... But some OS/browsers (_e.g. Ubuntu/Firefox_) default `Mod-k` to highlighting the browser url input. Therefore it's necessary to prevent the default behavior so once our link editing modal opens we can focus on the modal input for the ProseMirror editor link url.

_Focusing within a modal is a concrete example I currently have but imagine user intent when providing a key binding would be to override any default browser behavior._