### PR TITLE
Execute all matching key binding variations

### DIFF
--- a/src/keymap.ts
+++ b/src/keymap.ts
@@ -104,7 +104,7 @@ export function keydownHandler(bindings: {[key: string]: Command}): (view: Edito
         // Try falling back to the keyCode when there's a modifier
         // active or the character produced isn't ASCII, and our table
         // produces a different name from the the keyCode. See #668,
-        // #1060, #1529
+        // #1060, #1529.
         let fromCode = modifiers(baseName, event)
         if (execKey(view, map, fromCode)) return true
       }

--- a/test/test-keymap.ts
+++ b/test/test-keymap.ts
@@ -64,4 +64,18 @@ describe("keymap", () => {
     dispatch(keymap({"Mod-s": count}), "ы", {ctrlKey: true, keyCode: 83})
     ist(count.count, 1)
   })
+
+  it('tries all matching key binding variations', () => {
+    let keys = ["Shift-Control-Space", "s-Ctrl-Space", "s-c-Space"];
+    let records: Record<string, boolean> = {};
+    let createCommand = (key: string): Command => () => {
+      records[key] = true;
+      return false;
+    };
+    let map = Object.fromEntries(keys.map(key => [key, createCommand(key)]));
+    dispatch(keymap(map), " ", { ctrlKey: true, shiftKey: true });
+    for (let key of keys) {
+      ist(records[key], true);
+    }
+  })
 })


### PR DESCRIPTION
When users send two commands with the same key string to the `keymap()` plugin, it's expected that only one will be executed:

```ts
keymap({"c-Space": cmd1, "c-Space": cmd2})
// Only `cmd2` is actually passed to `keymap`, so it's normal for `cmd1` to be ignored.
```

However, when two commands with **different variations** of the **same key** are provided, `prosemirror-keymap` still executes only one of them, which I found to be a bit surprising.

```ts
keymap({"Ctrl-Space": cmd1, "c-Space": cmd2})
// Both `cmd1` and `cmd2` are passed to `keymap`, but only `cmd2` will be called.
```


> Modifiers can be given in any order. Shift- (or s-), Alt- (or a-), Ctrl- (or c- or Control-) and Cmd- (or m- or Meta-) are recognized. 
> ...
> You can use Mod- as a shorthand for Cmd- on Mac and Ctrl- on other platforms.


Some examples of similar variations include:

-  `Ctrl-Space` vs `Control-Space`: different variations of the same modifier
-  `Ctrl-Shift-Space` vs `Shift-Ctrl-Space`: different order of modifiers
-  `Mod-a` vs `mod-a`: Undocumented modifier. Although the document never stated that lower case `mod-` is a valid modifier, it works find.

This PR addresses the issue by allowing different variations of the same key.

---

An alternative approach would be for `prosemirror-keymap` to expose `normalizeKeyName` as a public API, allowing me to accomplish the same task externally.