### PR TITLE
Expose normalized bindings on `keydownHandler` fn

### DIFF
--- a/src/keymap.ts
+++ b/src/keymap.ts
@@ -71,12 +71,19 @@ export function keymap(bindings: {[key: string]: Command}): Plugin {
   return new Plugin({props: {handleKeyDown: keydownHandler(bindings)}})
 }
 
+/// A function that responds to
+/// [`EditorProps.handleKeyDown`](#view.EditorProps.handleKeyDown).
+export type KeydownHandler = ((view: EditorView, event: KeyboardEvent) => boolean) & {
+  /// The normalized key bindings that this handler responds to.
+  bindings: {[key: string]: Command}
+}
+
 /// Given a set of bindings (using the same format as
 /// [`keymap`](#keymap.keymap)), return a [keydown
 /// handler](#view.EditorProps.handleKeyDown) that handles them.
-export function keydownHandler(bindings: {[key: string]: Command}): (view: EditorView, event: KeyboardEvent) => boolean {
+export function keydownHandler(bindings: {[key: string]: Command}): KeydownHandler {
   let map = normalize(bindings)
-  return function(view, event) {
+  return Object.assign(function(view: EditorView, event: KeyboardEvent) {
     let name = keyName(event), baseName, direct = map[modifiers(name, event)]
     if (direct && direct(view.state, view.dispatch, view)) return true
     // A character key
@@ -98,5 +105,5 @@ export function keydownHandler(bindings: {[key: string]: Command}): (view: Edito
       }
     }
     return false
-  }
+  }, {bindings: map})
 }

--- a/test/test-keymap.ts
+++ b/test/test-keymap.ts
@@ -1,4 +1,4 @@
-import {keymap} from "prosemirror-keymap"
+import {keymap, keydownHandler} from "prosemirror-keymap"
 import {Command, Plugin} from "prosemirror-state"
 import ist from "ist"
 
@@ -63,5 +63,11 @@ describe("keymap", () => {
     let count = counter()
     dispatch(keymap({"Mod-s": count}), "ы", {ctrlKey: true, keyCode: 83})
     ist(count.count, 1)
+  })
+
+  it("exposes the normalized bindings", () => {
+    let a = counter()
+    let handler = keydownHandler({"control-shift-Enter": a})
+    ist(handler.bindings["Shift-Ctrl-Enter"], a)
   })
 })


### PR DESCRIPTION
I'd like to support two use cases that are made easier by having access to the normalized key bindings:

- Conditionally rendering editor toolbar buttons based on what plugins are enabled
- Dynamically generating a "keyboard shortcuts" help page and button tooltips using that platform's keyboard conventions

With this change, I can loop over my editor's plugins and build the platform-specific version of the keyboard shortcut from the `props.handleKeyDown` function itself.